### PR TITLE
White list all hosts in ALLOWED_HOSTS setting

### DIFF
--- a/DEWSproject/settings/__init__.py
+++ b/DEWSproject/settings/__init__.py
@@ -1,2 +1,2 @@
-# from .settings_dev import *
-from .settings_prod import *
+from .settings_dev import *
+# from .settings_prod import *

--- a/DEWSproject/settings/__init__.py
+++ b/DEWSproject/settings/__init__.py
@@ -1,2 +1,2 @@
-from .settings_dev import *
-# from .settings_prod import *
+# from .settings_dev import *
+from .settings_prod import *

--- a/DEWSproject/settings/settings_prod.py
+++ b/DEWSproject/settings/settings_prod.py
@@ -4,6 +4,7 @@ SECRET_KEY = env('SECRET_KEY')
 
 DEBUG = env("DEBUG")
 
-ALLOWED_HOSTS = ['http://dewsapp.herokuapp.com', 'https://dewsapp.herokuapp.com', '127.0.0.1']
+# ALLOWED_HOSTS = ['http://dewsapp.herokuapp.com', 'https://dewsapp.herokuapp.com', '127.0.0.1']
+ALLOWED_HOSTS = ["*"]
 
 django_heroku.settings(locals())


### PR DESCRIPTION
In order to finish setup before final configurations, all hosts have been white listed in the ALLOWED_HOSTS setting