### PR TITLE
Fix: typo in defining whitenoise compression type

### DIFF
--- a/DEWSproject/settings/settings_prod.py
+++ b/DEWSproject/settings/settings_prod.py
@@ -22,4 +22,4 @@ DATABASES = {
 
 django_heroku.settings(locals())
 
-STATICFILES_STORAGE = "whitenoise.django.CompressedManifestStaticFilesStorage"
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"


### PR DESCRIPTION
Fix the typo in defining the whitenoise compression type by changing the name from django to storage